### PR TITLE
Refactor: move rejectionMessage into protocolData

### DIFF
--- a/index.js
+++ b/index.js
@@ -182,9 +182,7 @@ function writeFulfill (writer, data) {
 
 function writeReject (writer, data) {
   const transferIdBuffer = Buffer.from(data.transferId.replace(/-/g, ''), 'hex')
-  const rejectionReasonBuffer = maybeSerializeIlpError(data.rejectionReason)
   writer.write(transferIdBuffer)
-  writer.write(rejectionReasonBuffer)
   writeProtocolData(writer, data.protocolData)
 }
 
@@ -251,9 +249,8 @@ function readFulfill (reader) {
 
 function readReject (reader) {
   const transferId = uuidParse.unparse(reader.read(16))
-  const rejectionReason = readIlpError(reader)
   const protocolData = readProtocolData(reader)
-  return { transferId, rejectionReason, protocolData }
+  return { transferId, protocolData }
 }
 
 function deserialize (buffer) {
@@ -363,13 +360,12 @@ module.exports = {
     })
   },
   serializeReject (reject, requestId, protocolData) {
-    const { transferId, rejectionReason } = reject
+    const { transferId } = reject
     return serialize({
       type: TYPE_REJECT,
       requestId,
       data: {
         transferId,
-        rejectionReason,
         protocolData
       }
     })

--- a/test/indexSpec.js
+++ b/test/indexSpec.js
@@ -33,17 +33,6 @@ describe('Bilateral Transfer Protocol', () => {
 
     this.reject = {
       transferId: this.transfer.transferId,
-      rejectionReason: this.error
-    }
-
-    this.rejectBuf = {
-      transferId: this.transfer.transferId,
-      rejectionReason: this.errorBuf
-    }
-
-    this.rejectStr = {
-      transferId: this.transfer.transferId,
-      rejectionReason: this.errorStr
     }
 
     this.btpError = {
@@ -70,7 +59,7 @@ describe('Bilateral Transfer Protocol', () => {
       prepare1: Buffer.from([3, 0, 0, 0, 1, 129, 143, 180, 200, 56, 246, 128, 177, 71, 248, 168, 46, 177, 252, 251, 237, 137, 213, 0, 0, 0, 0, 0, 0, 3, 232, 219, 42, 249, 249, 219, 166, 255, 52, 179, 237, 173, 251, 152, 107, 155, 180, 205, 75, 75, 65, 229, 4, 65, 25, 197, 93, 52, 175, 218, 191, 252, 2, 19, 50, 48, 49, 55, 48, 56, 50, 56, 48, 57, 51, 50, 48, 48, 46, 48, 48, 48, 90, 1, 4, 3, 105, 108, 112, 0, 30, 1, 28, 0, 0, 0, 0, 0, 0, 0, 100, 17, 101, 120, 97, 109, 112, 108, 101, 46, 114, 101, 100, 46, 97, 108, 105, 99, 101, 0, 0, 3, 102, 111, 111, 0, 3, 98, 97, 114, 4, 98, 101, 101, 112, 1, 4, 98, 111, 111, 112, 4, 106, 115, 111, 110, 2, 2, 123, 125]),
       prepare2: Buffer.from([3, 0, 0, 0, 1, 129, 143, 180, 200, 56, 246, 128, 177, 71, 248, 168, 46, 177, 252, 251, 237, 137, 213, 0, 0, 1, 31, 113, 251, 4, 203, 219, 42, 249, 249, 219, 166, 255, 52, 179, 237, 173, 251, 152, 107, 155, 180, 205, 75, 75, 65, 229, 4, 65, 25, 197, 93, 52, 175, 218, 191, 252, 2, 19, 50, 48, 49, 55, 48, 56, 50, 56, 48, 57, 51, 50, 48, 48, 46, 48, 48, 48, 90, 1, 4, 3, 105, 108, 112, 0, 30, 1, 28, 0, 0, 0, 0, 0, 0, 0, 100, 17, 101, 120, 97, 109, 112, 108, 101, 46, 114, 101, 100, 46, 97, 108, 105, 99, 101, 0, 0, 3, 102, 111, 111, 0, 3, 98, 97, 114, 4, 98, 101, 101, 112, 1, 4, 98, 111, 111, 112, 4, 106, 115, 111, 110, 2, 2, 123, 125]),
       fulfill: Buffer.from([4, 0, 0, 0, 1, 115, 180, 200, 56, 246, 128, 177, 71, 248, 168, 46, 177, 252, 251, 237, 137, 213, 219, 42, 249, 249, 219, 166, 255, 52, 179, 237, 173, 251, 152, 107, 155, 180, 205, 75, 75, 65, 229, 4, 65, 25, 197, 93, 52, 175, 218, 191, 252, 2, 1, 4, 3, 105, 108, 112, 0, 30, 1, 28, 0, 0, 0, 0, 0, 0, 0, 100, 17, 101, 120, 97, 109, 112, 108, 101, 46, 114, 101, 100, 46, 97, 108, 105, 99, 101, 0, 0, 3, 102, 111, 111, 0, 3, 98, 97, 114, 4, 98, 101, 101, 112, 1, 4, 98, 111, 111, 112, 4, 106, 115, 111, 110, 2, 2, 123, 125]),
-      reject: Buffer.from([5, 0, 0, 0, 1, 129, 152, 180, 200, 56, 246, 128, 177, 71, 248, 168, 46, 177, 252, 251, 237, 137, 213, 8, 67, 76, 49, 51, 9, 101, 114, 114, 111, 114, 78, 97, 109, 101, 5, 112, 101, 101, 114, 46, 1, 3, 6, 100, 105, 101, 32, 100, 97, 6, 100, 105, 101, 32, 100, 97, 6, 100, 105, 101, 32, 100, 97, 19, 50, 48, 49, 55, 48, 56, 50, 56, 48, 57, 51, 50, 48, 48, 46, 48, 48, 48, 90, 3, 98, 111, 111, 0, 1, 4, 3, 105, 108, 112, 0, 30, 1, 28, 0, 0, 0, 0, 0, 0, 0, 100, 17, 101, 120, 97, 109, 112, 108, 101, 46, 114, 101, 100, 46, 97, 108, 105, 99, 101, 0, 0, 3, 102, 111, 111, 0, 3, 98, 97, 114, 4, 98, 101, 101, 112, 1, 4, 98, 111, 111, 112, 4, 106, 115, 111, 110, 2, 2, 123, 125]),
+      reject: Buffer.from([5, 0, 0, 0, 1, 83, 180, 200, 56, 246, 128, 177, 71, 248, 168, 46, 177, 252, 251, 237, 137, 213, 1, 4, 3, 105, 108, 112, 0, 30, 1, 28, 0, 0, 0, 0, 0, 0, 0, 100, 17, 101, 120, 97, 109, 112, 108, 101, 46, 114, 101, 100, 46, 97, 108, 105, 99, 101, 0, 0, 3, 102, 111, 111, 0, 3, 98, 97, 114, 4, 98, 101, 101, 112, 1, 4, 98, 111, 111, 112, 4, 106, 115, 111, 110, 2, 2, 123, 125]),
       message: Buffer.from([6, 0, 0, 0, 1, 67, 1, 4, 3, 105, 108, 112, 0, 30, 1, 28, 0, 0, 0, 0, 0, 0, 0, 100, 17, 101, 120, 97, 109, 112, 108, 101, 46, 114, 101, 100, 46, 97, 108, 105, 99, 101, 0, 0, 3, 102, 111, 111, 0, 3, 98, 97, 114, 4, 98, 101, 101, 112, 1, 4, 98, 111, 111, 112, 4, 106, 115, 111, 110, 2, 2, 123, 125])
     }
   })
@@ -152,44 +141,17 @@ describe('Bilateral Transfer Protocol', () => {
   })
 
   describe('Reject', () => {
-    it.skip('should serialize/deserialize without losing data', function () {
+    it('should serialize/deserialize without losing data', function () {
       const obj = {
         type: Btp.TYPE_REJECT,
         requestId: 1,
         data: {
           protocolData: this.protocolData,
           transferId: this.fulfill.transferId,
-          rejectionReason: this.error
         }
       }
       assert.deepEqual(Btp.serialize(obj), this.buffers.reject)
       assert.deepEqual(Btp.deserialize(this.buffers.reject), obj)
-    })
-
-    it('should serialize from buffer without losing data', function () {
-      const objWithBuf = {
-        type: Btp.TYPE_REJECT,
-        requestId: 1,
-        data: {
-          protocolData: this.protocolData,
-          transferId: this.fulfill.transferId,
-          rejectionReason: this.errorBuf
-        }
-      }
-      assert.deepEqual(Btp.serialize(objWithBuf), this.buffers.reject)
-    })
-
-    it('should serialize from string without losing data', function () {
-      const objWithStr = {
-        type: Btp.TYPE_REJECT,
-        requestId: 1,
-        data: {
-          protocolData: this.protocolData,
-          transferId: this.fulfill.transferId,
-          rejectionReason: this.errorStr
-        }
-      }
-      assert.deepEqual(Btp.serialize(objWithStr), this.buffers.reject)
     })
   })
 
@@ -245,16 +207,6 @@ describe('Bilateral Transfer Protocol', () => {
   describe('serializeReject', () => {
     it('should serialize without losing data', function () {
       const buf = Btp.serializeReject(this.reject, 1, this.protocolData)
-      assert.deepEqual(buf, this.buffers.reject)
-    })
-
-    it('should serialize from buffer without losing data', function () {
-      const buf = Btp.serializeReject(this.rejectBuf, 1, this.protocolData)
-      assert.deepEqual(buf, this.buffers.reject)
-    })
-
-    it('should serialize from string without losing data', function () {
-      const buf = Btp.serializeReject(this.rejectStr, 1, this.protocolData)
       assert.deepEqual(buf, this.buffers.reject)
     })
   })


### PR DESCRIPTION
The `Reject` type message included an ILP Error, which broke symmetry with the way ILP is treated in the other message types (as a sub-protocol). This removes the rejectionMessage from `Reject` so the ILP rejection reason is in the protocolData.