### PR TITLE
perf: use oer-utils#dj-alloc-writer

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,4 @@
-import { Reader, Writer } from 'oer-utils'
+import { Predictor, Reader, Writer, WriterInterface } from 'oer-utils'
 import dateFormat = require('dateformat')
 
 // These constants are increased by 1 for BTP version Alpha
@@ -30,6 +30,22 @@ export function typeToString (type: Type) {
 
 const GENERALIZED_TIME_REGEX =
   /^([0-9]{4})([0-9]{2})([0-9]{2})([0-9]{2})([0-9]{2})([0-9]{2}\.[0-9]{3}Z)$/
+
+const protocolNameCache = createProtocolNameCache([
+  'ilp',
+  // BTP authentication:
+  'auth',
+  'auth_username',
+  'auth_token',
+  // ilp-plugin-xrp-asym-{client,server}:
+  'channel',
+  'channel_signature',
+  'claim',
+  'fund_channel',
+  'info',
+  'last_claim'
+])
+
 
 // Notes about variable naming - comparison with asn.1 definition:
 //
@@ -63,7 +79,19 @@ export interface ProtocolData {
   data: Buffer
 }
 
-function writeProtocolData (writer: Writer, protocolData: ProtocolData[]) {
+// Generate a cache of the most commonly used BTP subprotocol names.
+// The goal is to avoid an extra buffer allocation when serializing.
+function createProtocolNameCache (canonProtocolNames: string[]): {[s: string]: Buffer} {
+  // Cache the most common BTP subprotocol names so that a new buffer doesn't need
+  // to be allocated each serialize().
+  const cache = {}
+  for (const protocolName of canonProtocolNames) {
+    cache[protocolName] = Buffer.from(protocolName, 'ascii')
+  }
+  return cache
+}
+
+function writeProtocolData (writer: WriterInterface, protocolData: ProtocolData[]) {
   if (!Array.isArray(protocolData)) {
     throw new Error('protocolData must be an array')
   }
@@ -76,7 +104,9 @@ function writeProtocolData (writer: Writer, protocolData: ProtocolData[]) {
   writer.writeUInt(lengthPrefix, lengthPrefixLengthPrefix)
 
   for (const p of protocolData) {
-    writer.writeVarOctetString(Buffer.from(p.protocolName, 'ascii'))
+    writer.writeVarOctetString(
+      protocolNameCache[p.protocolName] ||
+      Buffer.from(p.protocolName, 'ascii'))
     writer.writeUInt8(p.contentType)
     writer.writeVarOctetString(p.data)
   }
@@ -105,7 +135,7 @@ export interface BtpTransfer {
   protocolData: ProtocolData[]
 }
 
-function writeTransfer (writer: Writer, data: BtpTransfer) {
+function writeTransfer (writer: WriterInterface, data: BtpTransfer) {
   writer.writeUInt64(data.amount)
   writeProtocolData(writer, data.protocolData)
 }
@@ -118,7 +148,7 @@ export interface BtpError {
   protocolData: ProtocolData[]
 }
 
-function writeError (writer: Writer, data: BtpError) {
+function writeError (writer: WriterInterface, data: BtpError) {
   if (data.code.length !== 3) {
     throw new Error(`error code must be 3 characters, got: "${data.code}"`)
   }
@@ -166,34 +196,38 @@ export interface BtpErrorPacket {
 
 export type BtpPacket = BtpResponsePacket | BtpMessagePacket | BtpTransferPacket | BtpErrorPacket
 
-export function serialize (obj: BtpPacket) {
-  const contentsWriter = new Writer()
+function writeContents (writer: WriterInterface, obj: BtpPacket) {
   switch (obj.type) {
     case Type.TYPE_RESPONSE:
     case Type.TYPE_MESSAGE:
-      writeProtocolData(contentsWriter, obj.data.protocolData)
+      writeProtocolData(writer, obj.data.protocolData)
       break
-
     case Type.TYPE_TRANSFER:
-      writeTransfer(contentsWriter, obj.data)
+      writeTransfer(writer, obj.data)
       break
-
     case Type.TYPE_ERROR:
-      writeError(contentsWriter, obj.data)
+      writeError(writer, obj.data)
       break
-
     default:
       throw new Error('Unrecognized type')
   }
+}
 
-  const envelopeWriter = new Writer()
+export function serialize (obj: BtpPacket): Buffer {
+  const contentsPredictor = new Predictor()
+  writeContents(contentsPredictor, obj)
+  const envelopeSize = 1 + 4 +
+    Predictor.measureVarOctetString(contentsPredictor.length)
+
+  const envelopeWriter = new Writer(envelopeSize)
   envelopeWriter.writeUInt8(obj.type)
   envelopeWriter.writeUInt32(obj.requestId)
-  envelopeWriter.writeVarOctetString(contentsWriter)
+  const contentsWriter = envelopeWriter.createVarOctetString(contentsPredictor.length)
+  writeContents(contentsWriter, obj)
   return envelopeWriter.getBuffer()
 }
 
-function readTransfer (reader: Reader) {
+function readTransfer (reader: Reader): BtpTransfer {
   const amount = reader.readUInt64BigNum().toString(10)
   const protocolData = readProtocolData(reader)
   return { amount, protocolData }

--- a/package-lock.json
+++ b/package-lock.json
@@ -281,6 +281,16 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "benchmark": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-2.1.4.tgz",
+      "integrity": "sha1-CfPeMckWQl1JjMLuVloOvzwqVik=",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.4",
+        "platform": "^1.3.3"
+      }
+    },
     "bignumber.js": {
       "version": "7.2.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
@@ -1982,9 +1992,9 @@
       "dev": true
     },
     "oer-utils": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/oer-utils/-/oer-utils-3.2.0.tgz",
-      "integrity": "sha512-WYDTeRW15E1u+hfrIJQwAzLBFu/FAOiMgRa5j/sgrvED0gYbqkKZ4ApQgfdEMiXFzvEmdKQlGcUqmloz6y+WZg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/oer-utils/-/oer-utils-4.0.0.tgz",
+      "integrity": "sha512-WxX0gNGSS0Lzig4IdliHlIQ03PVTpIuLFbOAag5lJrx1hWNG3f/yhx3QOmORpoXe2e53HZbeet8qoOAsiWz5BQ==",
       "requires": {
         "bignumber.js": "^7.2.1"
       }
@@ -2020,6 +2030,12 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
+    },
+    "platform": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.5.tgz",
+      "integrity": "sha512-TuvHS8AOIZNAlE77WUDiR4rySV/VMptyMfcfeoMgs4P8apaZM3JrnbzBiixKUv+XR6i+BXrQh8WAnjaSPFO65Q==",
       "dev": true
     },
     "psl": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@types/dateformat": "^1.0.1",
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.7.0",
+    "benchmark": "^2.1.4",
     "chai": "^4.2.0",
     "codecov": "^3.0.4",
     "mocha": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/interledgerjs/btp-packet#readme",
   "dependencies": {
     "dateformat": "^3.0.3",
-    "oer-utils": "^3.2.0"
+    "oer-utils": "^4.0.0"
   },
   "devDependencies": {
     "@types/chai": "^4.1.4",

--- a/test/benchmarks/packet.ts
+++ b/test/benchmarks/packet.ts
@@ -1,0 +1,39 @@
+const Benchmark = require('benchmark')
+import * as PacketV1 from '../..'
+const packageV0 = process.argv[2]
+if (!packageV0) {
+  console.error('usage: node ' + process.argv.slice(0, 2).join(' ') + ' <v0>')
+  process.exit(1)
+}
+const PacketV0 = require(packageV0)
+
+const messagePacket: PacketV1.BtpMessagePacket = {
+  type: PacketV1.TYPE_MESSAGE,
+  requestId: 123,
+  data: {
+    protocolData: [{
+      protocolName: 'ilp',
+      contentType: PacketV1.MIME_APPLICATION_OCTET_STREAM,
+      data: Buffer.from('0c68000000000000006b323031373132323330313231343035343974e1136dc71c9e5f283bec83461cbf1261c4014f72d48f8dd65453a0b84e7de10d6578616d706c652e616c696365205db343fdc41898f6df4202329139dc242dd0f558a811b46b28918fdab37c6cb0', 'hex')
+    }]
+  }
+}
+const messageBuffer = PacketV1.serialize(messagePacket)
+
+// TODO test Transfer, Response, Error
+
+;(new Benchmark.Suite('serialize: Message'))
+  .add('v0', function () { PacketV0.serialize(messagePacket) })
+  .add('v1', function () { PacketV1.serialize(messagePacket) })
+  .on('cycle', function(event: any) {
+    console.log(this.name, '\t', String(event.target));
+  })
+  .run({})
+
+;(new Benchmark.Suite('deserialize: Message'))
+  .add('v0', function () { PacketV0.deserialize(messageBuffer) })
+  .add('v1', function () { PacketV1.deserialize(messageBuffer) })
+  .on('cycle', function(event: any) {
+    console.log(this.name, '\t', String(event.target));
+  })
+  .run({})

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -115,4 +115,13 @@ describe('BTP/1.0', () => {
       assert.deepEqual(buf, this.buffers.transfer)
     })
   })
+
+  describe('registerProtocolNames', function () {
+    it('caches the protocol names', function () {
+      Btp.registerProtocolNames(
+        this.protocolData.map((protocol: Btp.ProtocolData) => protocol.protocolName))
+      const buf = Btp.serializeMessage(1, this.protocolData)
+      assert.deepEqual(buf, this.buffers.message)
+    })
+  })
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
   },
   "include": [
     "index.ts",
-    "test/*.spec.ts"
+    "test/*.spec.ts",
+    "test/benchmarks/*.ts"
   ]
 }


### PR DESCRIPTION
Depends on https://github.com/interledgerjs/oer-utils/pull/21.

In addition to switching to the new oer-utils, common sub-protocol names are stored as buffers to avoid re-allocating copies every `serialize()`.

Benchmarks (before and after):

```
serialize:   Message     v0 x 250,978 ops/sec ±0.85% (91 runs sampled)
serialize:   Message     v1 x 862,162 ops/sec ±1.08% (94 runs sampled)
deserialize: Message     v0 x 735,601 ops/sec ±1.88% (94 runs sampled)
deserialize: Message     v1 x 2,605,169 ops/sec ±0.60% (92 runs sampled)
```